### PR TITLE
add Covariance methods

### DIFF
--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -53,9 +53,7 @@ Base.range(cov::Covariance) = maximum(radii(metricbal(cov.γ)))
 Scale metric ball of covariance `cov` with strictly
 positive scaling factor `s`.
 """
-function scale(cov::CovType, s::Real) where {CovType <: Covariance}
-  CovType(scale(cov.γ, s))
-end
+scale(cov::Cov, s::Real) where {Cov <: Covariance} = Cov(scale(cov.γ, s))
 
 """
     pairwise(cov, domain)

--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -17,10 +17,51 @@ Evaluate the covariance at objects `x₁` and `x₁`.
 (cov::Covariance)(x₁, x₂) = sill(cov.γ) - cov.γ(x₁, x₂)
 
 """
+    isstationary(cov)
+
+Check if covariance `cov` possesses the 2nd-order stationary property.
+"""
+isstationary(cov::Covariance) = isstationary(typeof(cov.γ))
+
+"""
+    isisotropic(cov)
+
+Tells whether or not covariance `cov` is isotropic.
+"""
+isisotropic(cov::Covariance) = isisotropic(cov.γ.ball)
+
+for fun in (:sill, :nugget, :metricball)
+  eval(quote
+    """
+        $($fun)(cov)
+
+    Returns the $($fun) of the covariance `cov`.
+    """
+    $fun(cov::Covariance) = $fun(cov.γ)
+  end)
+end
+
+"""
+    range(cov)
+
+Return the maximum range of the covariance `cov`."""
+Base.range(cov::Covariance) = maximum(radii(cov.γ.ball))
+
+"""
+    scale(cov, s)
+
+Scale metric ball of covariance `cov` with strictly
+positive scaling factor `s`.
+"""
+function scale(cov::CovType, s::Real) where {CovType <: Covariance}
+  CovType(scale(cov.γ, s))
+end
+
+"""
     pairwise(cov, domain)
-    
+
 Evaluate covariance `cov` between all elements in the `domain`.
-    
+
     pairwise(cov, domain₁, domain₂)
 
 Evaluate covariance `cov` between all elements of `domain₁` and `domain₂`.

--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -21,41 +21,41 @@ Evaluate the covariance at objects `x₁` and `x₁`.
 
 Check if covariance `cov` possesses the 2nd-order stationary property.
 """
-isstationary(cov::Covariance) = isstationary(typeof(cov.γ))
+isstationary(cov::Covariance) = isstationary(cov.γ)
 
 """
     isisotropic(cov)
 
 Tells whether or not covariance `cov` is isotropic.
 """
-isisotropic(cov::Covariance) = isisotropic(metricball(cov.γ))
+isisotropic(cov::Covariance) = isisotropic(cov.γ)
 
 """
     sill(cov)
 
 Return the sill of the covariance `cov`.
 """
-sill(cov::Covariance) = cov.γ.sill
+sill(cov::Covariance) = sill(cov.γ)
 
 """
     nugget(cov)
 
 Return the nugget of the covariance `cov`.
 """
-nugget(cov::Covariance) = cov.γ.nugget
+nugget(cov::Covariance) = nugget(cov.γ)
 
 """
     metricball(cov)
 
 Return the metric ball of the covariance `cov`.
 """
-metricball(cov::Covariance) = cov.γ.ball
+metricball(cov::Covariance) = metricball(cov.γ)
 
 """
     range(cov)
 
 Return the maximum range of the covariance `cov`."""
-Base.range(cov::Covariance) = maximum(radii(metricball(cov.γ)))
+Base.range(cov::Covariance) = range(cov.γ)
 
 """
     scale(cov, s)

--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -30,22 +30,32 @@ Tells whether or not covariance `cov` is isotropic.
 """
 isisotropic(cov::Covariance) = isisotropic(metricball(cov.γ))
 
-for fun in (:sill, :nugget, :metricball)
-  eval(quote
-    """
-        $($fun)(cov)
+"""
+    sill(cov)
 
-    Returns the $($fun) of the covariance `cov`.
-    """
-    $fun(cov::Covariance) = $fun(cov.γ)
-  end)
-end
+Return the sill of the covariance `cov`.
+"""
+sill(cov::Covariance) = cov.γ.sill
+
+"""
+    nugget(cov)
+
+Return the nugget of the covariance `cov`.
+"""
+nugget(cov::Covariance) = cov.γ.nugget
+
+"""
+    metricball(cov)
+
+Return the metric ball of the covariance `cov`.
+"""
+metricball(cov::Covariance) = cov.γ.ball
 
 """
     range(cov)
 
 Return the maximum range of the covariance `cov`."""
-Base.range(cov::Covariance) = maximum(radii(metricbal(cov.γ)))
+Base.range(cov::Covariance) = maximum(radii(metricball(cov.γ)))
 
 """
     scale(cov, s)

--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -10,13 +10,6 @@ Parent type of all covariance functions (e.g. Gaussian covariance).
 abstract type Covariance end
 
 """
-    cov(x₁, x₂)
-
-Evaluate the covariance at objects `x₁` and `x₁`.
-"""
-(cov::Covariance)(x₁, x₂) = sill(cov.γ) - cov.γ(x₁, x₂)
-
-"""
     isstationary(cov)
 
 Check if covariance `cov` possesses the 2nd-order stationary property.
@@ -54,7 +47,8 @@ metricball(cov::Covariance) = metricball(cov.γ)
 """
     range(cov)
 
-Return the maximum range of the covariance `cov`."""
+Return the maximum range of the covariance `cov`.
+"""
 Base.range(cov::Covariance) = range(cov.γ)
 
 """
@@ -64,6 +58,13 @@ Scale metric ball of covariance `cov` with strictly
 positive scaling factor `s`.
 """
 scale(cov::Cov, s::Real) where {Cov <: Covariance} = Cov(scale(cov.γ, s))
+
+"""
+    cov(g₁, g₂)
+
+Evaluate the covariance at geometries `g₁` and `g₁`.
+"""
+(cov::Covariance)(g₁, g₂) = sill(cov.γ) - cov.γ(g₁, g₂)
 
 """
     pairwise(cov, domain)

--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -28,7 +28,7 @@ isstationary(cov::Covariance) = isstationary(typeof(cov.γ))
 
 Tells whether or not covariance `cov` is isotropic.
 """
-isisotropic(cov::Covariance) = isisotropic(cov.γ.ball)
+isisotropic(cov::Covariance) = isisotropic(metricball(cov.γ))
 
 for fun in (:sill, :nugget, :metricball)
   eval(quote
@@ -45,7 +45,7 @@ end
     range(cov)
 
 Return the maximum range of the covariance `cov`."""
-Base.range(cov::Covariance) = maximum(radii(cov.γ.ball))
+Base.range(cov::Covariance) = maximum(radii(metricbal(cov.γ)))
 
 """
     scale(cov, s)

--- a/test/covariance.jl
+++ b/test/covariance.jl
@@ -40,6 +40,15 @@
   @test eltype(Γ_f) == Float32
   @test issymmetric(Γ_f)
 
+  cov = GaussianCovariance(range=1.0, sill=1.0, nugget=0.0)
+  @test isstationary(cov)
+  @test isisotropic(cov)
+  @test sill(cov) == 1.0
+  @test nugget(cov) == 0.0
+  @test metricball(cov) == MetricBall(1.0)
+  @test range(cov) == 1.0
+  @test scale(cov, 2) == GaussianCovariance(range=2.0, sill=1.0, nugget=0.0)
+
   # shows
   cov = CircularCovariance()
   @test sprint(show, cov) == "CircularCovariance(sill: 1.0, nugget: 0.0, range: 1.0, distance: Euclidean)"

--- a/test/covariance.jl
+++ b/test/covariance.jl
@@ -47,7 +47,7 @@
   @test nugget(cov) == 0.0
   @test metricball(cov) == MetricBall(1.0)
   @test range(cov) == 1.0
-  @test scale(cov, 2) == GaussianCovariance(range=2.0, sill=1.0, nugget=0.0)
+  @test GeoStatsFunctions.scale(cov, 2) == GaussianCovariance(range=2.0, sill=1.0, nugget=0.0)
 
   # shows
   cov = CircularCovariance()


### PR DESCRIPTION
I added methods for `Covariance` types that weren't initially implemented:
* `isstationary`
* `isisotropic`
* `sill`
* `nugget`
* `metricball`
* `Base.range`
* `scale`

All of these methods pass the call to the underlying variogram, so I didn't add any new tests.

I did confirm that the example in the linked issue now works:
```julia
field = rand(
    GaussianCovariance() |> GaussianProcess,
    CartesianGrid(10, 10),
    :x => Float64,
)
```
closes JuliaEarth/GeoStats.jl#404