### PR TITLE
add pairwise! for Covariance types

### DIFF
--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -37,8 +37,9 @@ Evaluates covariance `cov` between all elements in the `domain` in-place, fillin
 Evaluates covariance `cov` between all elements of `domain₁` and `domain₂` in-place, filling the matrix `Γ`."""
 function pairwise!(Γ, cov::Covariance, args...)
   pairwise!(Γ, cov.γ, args...)
-  Γ .*= -one(eltype(Γ))
-  Γ .+= sill(cov.γ)
+  for i ∈ eachindex(Γ)
+    Γ[i] = sill(cov.γ) - Γ[i]
+  end
   Γ
 end
 

--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -18,14 +18,29 @@ Evaluate the covariance at objects `x₁` and `x₁`.
 
 """
     pairwise(cov, domain)
-    
+
 Evaluate covariance `cov` between all elements in the `domain`.
-    
+
     pairwise(cov, domain₁, domain₂)
 
 Evaluate covariance `cov` between all elements of `domain₁` and `domain₂`.
 """
 pairwise(cov::Covariance, args...) = sill(cov.γ) .- pairwise(cov.γ, args...)
+
+"""
+    pairwise!(Γ, cov, domain)
+
+Evaluates covariance `cov` between all elements in the `domain` in-place, filling the matrix `Γ`.
+
+    pairwise!(Γ, cov, domain₁, domain₂)
+
+Evaluates covariance `cov` between all elements of `domain₁` and `domain₂` in-place, filling the matrix `Γ`."""
+function pairwise!(Γ, cov::Covariance, args...)
+  pairwise!(Γ, cov.γ, args...)
+  Γ .*= -one(eltype(Γ))
+  Γ .+= sill(cov.γ)
+  Γ
+end
 
 # -----------
 # IO METHODS

--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -28,19 +28,20 @@ Evaluate covariance `cov` between all elements of `domain₁` and `domain₂`.
 pairwise(cov::Covariance, args...) = sill(cov.γ) .- pairwise(cov.γ, args...)
 
 """
-    pairwise!(Γ, cov, domain)
+    pairwise!(C, cov, domain)
 
-Evaluates covariance `cov` between all elements in the `domain` in-place, filling the matrix `Γ`.
+Evaluates covariance `cov` between all elements in the `domain` in-place, filling the matrix `C`.
 
-    pairwise!(Γ, cov, domain₁, domain₂)
+    pairwise!(C, cov, domain₁, domain₂)
 
-Evaluates covariance `cov` between all elements of `domain₁` and `domain₂` in-place, filling the matrix `Γ`."""
-function pairwise!(Γ, cov::Covariance, args...)
-  pairwise!(Γ, cov.γ, args...)
-  for i ∈ eachindex(Γ)
-    Γ[i] = sill(cov.γ) - Γ[i]
+Evaluates covariance `cov` between all elements of `domain₁` and `domain₂` in-place, filling the matrix `C`.
+"""
+function pairwise!(C, cov::Covariance, args...)
+  pairwise!(C, cov.γ, args...)
+  for i in eachindex(Γ)
+    C[i] = sill(cov.γ) - C[i]
   end
-  Γ
+  C
 end
 
 # -----------

--- a/src/variogram.jl
+++ b/src/variogram.jl
@@ -191,7 +191,7 @@ function pairwise(γ::Variogram, domain₁, domain₂)
 end
 
 """
-    pairwise!(Γ, γ, domain)
+    pairwise!(Γ, γ, domain₁, domain₂)
 
 Evaluates covariance `γ` between all elements of `domain₁` and `domain₂` in-place, filling the matrix `Γ`.
 """

--- a/src/variogram.jl
+++ b/src/variogram.jl
@@ -152,6 +152,11 @@ function pairwise(γ::Variogram, domain)
   pairwise!(Γ, γ, domain)
 end
 
+"""
+    pairwise!(Γ, γ, domain)
+
+Evaluates covariance `γ` between all elements in the `domain` in-place, filling the matrix `Γ`.
+"""
 function pairwise!(Γ, γ::Variogram, domain)
   n = length(domain)
   @inbounds for j in 1:n
@@ -185,6 +190,11 @@ function pairwise(γ::Variogram, domain₁, domain₂)
   pairwise!(Γ, γ, domain₁, domain₂)
 end
 
+"""
+    pairwise!(Γ, γ, domain)
+
+Evaluates covariance `γ` between all elements of `domain₁` and `domain₂` in-place, filling the matrix `Γ`.
+"""
 function pairwise!(Γ, γ::Variogram, domain₁, domain₂)
   m = length(domain₁)
   n = length(domain₂)

--- a/test/covariance.jl
+++ b/test/covariance.jl
@@ -40,6 +40,11 @@
   @test eltype(Γ_f) == Float32
   @test issymmetric(Γ_f)
 
+  𝒟 = PointSet(Matrix(1.0I, 3, 3))
+  Γ = Matrix{Float64}(undef, 3, 3)
+  GeoStatsFunctions.pairwise!(Γ, GaussianCovariance(range=1.0, sill=1.0, nugget=1.0), 𝒟)
+  @test issymmetric(Γ)
+
   # shows
   cov = CircularCovariance()
   @test sprint(show, cov) == "CircularCovariance(sill: 1.0, nugget: 0.0, range: 1.0, distance: Euclidean)"


### PR DESCRIPTION
This adds the `pairwise!` function for `Covariance` types. I also added a docstring for the variogram's `pairwise!` method.

closes JuliaEarth/GeoStats.jl#405

I did also notice that the existing implementation allocates a lot of memory even though it should just be filling a destination matrix. For example:
```julia
julia> grid = CartesianGrid((2, 3))
2×3 CartesianGrid{2,Float64}
  minimum: Point(0.0, 0.0)
  maximum: Point(2.0, 3.0)
  spacing: (1.0, 1.0)

julia> A = zeros(6, 6)
6×6 Matrix{Float64}:
 0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0

julia> γ = GaussianVariogram()
GaussianVariogram
├─ sill: 1.0
├─ nugget: 0.0
├─ range: 1.0
└─ distance: Euclidean

julia> @benchmark GeoStatsFunctions.pairwise!($A, $γ, $grid)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  429.125 μs …   1.775 ms  ┊ GC (min … max): 0.00% … 72.74%
 Time  (median):     438.125 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   462.660 μs ± 165.411 μs  ┊ GC (mean ± σ):  5.08% ± 10.09%

  █▃                                                            ▁
  ██▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇█▆▄▃▃▁▁▁▁▁▁▅ █
  429 μs        Histogram: log(frequency) by time       1.69 ms <

 Memory estimate: 948.28 KiB, allocs estimate: 7707.
```
I'm not exactly sure why and I didn't want to mess with the original implementation.