### PR TITLE
use annotation! instead of text! for variograms

### DIFF
--- a/ext/GeoStatsFunctionsMakieExt/funplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/funplot.jl
@@ -182,7 +182,7 @@ function funplot!(
 
     # visualize text counts
     if showtext
-      Makie.text!(ax, hs, fs, text=string.(ns), fontsize=textsize)
+      Makie.annotation!(ax, hs, fs, text=string.(ns), fontsize=textsize)
     end
   end
   fig


### PR DESCRIPTION
It seems that the new Makie `annotation!` could help with [variograms](https://juliaearth.github.io/GeoStatsDocs/stable/variograms/#(Omini)directional-variograms) to make the number of pairs more readable. 

I did not test it on a variogram yet (the multi repo structure scares me a bit!). I'll try to do it if you don't have time.