### PR TITLE
Refactor funplot and surfplot for Makie layout composition

### DIFF
--- a/ext/GeoStatsFunctionsMakieExt/GeoStatsFunctionsMakieExt.jl
+++ b/ext/GeoStatsFunctionsMakieExt/GeoStatsFunctionsMakieExt.jl
@@ -14,8 +14,8 @@ import Makie
 import GeoStatsFunctions: funplot, funplot!
 import GeoStatsFunctions: surfplot, surfplot!
 
+include("utils.jl")
 include("funplot.jl")
 include("surfplot.jl")
-include("utils.jl")
 
 end

--- a/ext/GeoStatsFunctionsMakieExt/GeoStatsFunctionsMakieExt.jl
+++ b/ext/GeoStatsFunctionsMakieExt/GeoStatsFunctionsMakieExt.jl
@@ -14,7 +14,7 @@ import Makie
 import GeoStatsFunctions: funplot, funplot!
 import GeoStatsFunctions: surfplot, surfplot!
 
-include("utils.jl")
+include("utils.jl") 
 include("funplot.jl")
 include("surfplot.jl")
 

--- a/ext/GeoStatsFunctionsMakieExt/funplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/funplot.jl
@@ -58,10 +58,13 @@ function funplot!(
   for i in 1:n, j in 1:n
     ax = Makie.content(layout[i, j])
     for (k, Fₖ) in enumerate(F)
+      # display function
       Makie.lines!(ax, hs, Fₖ[i, j], color=color, linewidth=size, linestyle=style[k], label=label[k])
       if _istransiogram(f)
         if i == j
+          # display mean lengths
           Makie.lines!(ax, [zero(hmax), l[i]], [1.0, 0.0], color=:slategray, linewidth=size, linestyle=:dash)
+          # display proportions
           Makie.hlines!(ax, p[i], color=:slategray, linewidth=size, linestyle=:dash)
         end
       end
@@ -75,8 +78,13 @@ end
 _eval(f, hs) = isisotropic(f) ? _isoeval(f, hs) : _anisoeval(f, hs)
 
 function _isoeval(f, hs)
+  # auxiliary parameters
   n = nvariates(f)
+
+  # evaluate all lags
   fs = f.(hs)
+
+  # reshape result
   Fᵢₛₒ = [getindex.(fs, i, j) for i in 1:n, j in 1:n]
   [Fᵢₛₒ]
 end

--- a/ext/GeoStatsFunctionsMakieExt/funplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/funplot.jl
@@ -3,15 +3,17 @@
 # ------------------------------------------------------------------
 
 function funplot(f; labels=nothing, kwargs...)
-  fig = Makie.Figure()
   # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
+
   # initialize figure
+  fig = Makie.Figure()
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
     Makie.Axis(fig[i, j], title=title)
   end
+
   # fill figure with plots
   funplot!(fig.layout, f; kwargs...)
   fig
@@ -21,12 +23,14 @@ function funplot(pos, f; labels=nothing, kwargs...)
   # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
+
   # initialize figure
   layout = _layout(pos)
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
     Makie.Axis(layout[i, j], title=title)
   end
+
   # fill figure with plots
   funplot!(layout, f; kwargs...)
   pos
@@ -42,16 +46,21 @@ function funplot!(
 )
   # maximum lag
   hmax = isnothing(maxlag) ? _maxlag(f) : GeoStatsFunctions.aslen(maxlag)
+
   # lag range starting at 1e-6 to avoid nugget artifact
   hs = range(1e-6 * oneunit(hmax), stop=hmax, length=100)
+
   # evaluate function
   F = _eval(f, hs)
+
   # mean lengths and proportions
   l = _istransiogram(f) ? meanlengths(f) : nothing
   p = _istransiogram(f) ? proportions(f) : nothing
+
   # aesthetic options
   label = Dict(1 => "1ˢᵗ axis", 2 => "2ⁿᵈ axis", 3 => "3ʳᵈ axis")
   style = Dict(1 => :solid, 2 => :dash, 3 => :dot)
+
   # add plots to axes
   d = length(F)
   n = nvariates(f)
@@ -86,6 +95,7 @@ function _isoeval(f, hs)
 
   # reshape result
   Fᵢₛₒ = [getindex.(fs, i, j) for i in 1:n, j in 1:n]
+
   [Fᵢₛₒ]
 end
 
@@ -136,26 +146,39 @@ function funplot!(
 )
   # number of variables
   n = nvariates(f)
+
   # add plots to axes
   for i in 1:n, j in 1:n
     ax = Makie.content(layout[i, j])
+
     # retrieve coordinates and counts
     hs = f.abscissas
     fs = _istransiogram(f) ? f.ordinates[i, j] : f.ordinates
     ns = f.counts
+
+    # retrieve maximum lag
     hmax = isnothing(maxlag) ? _maxlag(f) : GeoStatsFunctions.aslen(maxlag)
+
+    # discard empty bins
     hs = hs[ns .> 0]
     fs = fs[ns .> 0]
     ns = ns[ns .> 0]
+
     # discard above maximum lag
     ns = ns[hs .≤ hmax]
     fs = fs[hs .≤ hmax]
     hs = hs[hs .≤ hmax]
+
+    # visualize histogram
     if showhist
       ms = ns * (maximum(fs) / maximum(ns)) / 10
       Makie.barplot!(ax, hs, ms, color=histcolor, alpha=0.3, gap=0.0)
     end
+
+    # visualize function
     Makie.scatterlines!(ax, hs, fs, color=color, markersize=pointsize, linewidth=size, linestyle=style)
+
+    # visualize text counts
     if showtext
       Makie.annotation!(ax, hs, fs, text=string.(ns), fontsize=textsize)
     end

--- a/ext/GeoStatsFunctionsMakieExt/funplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/funplot.jl
@@ -4,24 +4,30 @@
 
 function funplot(f; labels=nothing, kwargs...)
   fig = Makie.Figure()
+  # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
+  # initialize figure
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
     Makie.Axis(fig[i, j], title=title)
   end
+  # fill figure with plots
   funplot!(fig, f; kwargs...)
   fig
 end
 
 function funplot(gp::GridPos, f; labels=nothing, kwargs...)
+  # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
+  # initialize figure
   layout = _layout(gp)
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
     Makie.Axis(layout[i, j], title=title)
   end
+  # fill figure with plots
   funplot!(layout, f; kwargs...)
   gp
 end
@@ -29,17 +35,24 @@ end
 function funplot!(
   layout::Union{Makie.Figure, Makie.GridLayout},
   f::GeoStatsFunction;
+  # common options
   color=:teal,
   size=1.5,
   maxlag=nothing
 )
+  # maximum lag
   hmax = isnothing(maxlag) ? _maxlag(f) : GeoStatsFunctions.aslen(maxlag)
+  # lag range starting at 1e-6 to avoid nugget artifact
   hs = range(1e-6 * oneunit(hmax), stop=hmax, length=100)
+  # evaluate function
   F = _eval(f, hs)
+  # mean lengths and proportions
   l = _istransiogram(f) ? meanlengths(f) : nothing
   p = _istransiogram(f) ? proportions(f) : nothing
+  # aesthetic options
   label = Dict(1 => "1ˢᵗ axis", 2 => "2ⁿᵈ axis", 3 => "3ʳᵈ axis")
   style = Dict(1 => :solid, 2 => :dash, 3 => :dot)
+  # add plots to axes
   d = length(F)
   n = nvariates(f)
   gl = layout isa Makie.Figure ? layout.layout : layout
@@ -104,6 +117,7 @@ end
 function funplot!(
   layout::Union{Makie.Figure, Makie.GridLayout},
   f::EmpiricalGeoStatsFunction;
+  # common options
   color=:slategray,
   size=1.5,
   maxlag=nothing,

--- a/ext/GeoStatsFunctionsMakieExt/funplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/funplot.jl
@@ -2,24 +2,33 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-function funplot(f; labels=nothing, kwargs...)
+function funplot(gp::GridPos, f; labels=nothing, kwargs...)
   # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
 
-  # initialize figure
-  fig = Makie.Figure()
+  layout = get_layout(gp)
+
+  # initialize axis grid
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
-    Makie.Axis(fig[i, j], title=title)
+    Makie.Axis(layout[i, j], title=title)
   end
 
   # fill figure with plots
-  funplot!(fig, f; kwargs...)
+  funplot!(gp, f; kwargs...)
+
+  gp
+end
+
+function funplot(f; figure=(;), kwargs...)
+  fig = Makie.Figure(; figure...)
+  funplot(fig, f; kwargs...)
+  fig
 end
 
 function funplot!(
-  fig::Makie.Figure,
+  gp::GridPos,
   f::GeoStatsFunction;
   # common options
   color=:teal,
@@ -46,9 +55,9 @@ function funplot!(
   # add plots to axes
   d = length(F)
   n = nvariates(f)
-  I = LinearIndices((n, n))
+  layout = get_layout(gp)
   for i in 1:n, j in 1:n
-    ax = fig.content[I[j, i]]
+    ax = Makie.content(layout[i, j])
     for (k, Fₖ) in enumerate(F)
       # display function
       Makie.lines!(ax, hs, Fₖ[i, j], color=color, linewidth=size, linestyle=style[k], label=label[k])
@@ -64,7 +73,7 @@ function funplot!(
     position = (i == j) && isbanded(f) ? :rt : :rb
     d > 1 && Makie.axislegend(ax, position=position)
   end
-  fig
+  gp
 end
 
 _eval(f, hs) = isisotropic(f) ? _isoeval(f, hs) : _anisoeval(f, hs)
@@ -131,7 +140,7 @@ function _anisobasis(f::CarleTransiogram{N}) where {N}
 end
 
 function funplot!(
-  fig::Makie.Figure,
+  gp::GridPos,
   f::EmpiricalGeoStatsFunction;
   # common options
   color=:slategray,
@@ -147,11 +156,11 @@ function funplot!(
 )
   # number of variables
   n = nvariates(f)
-  I = LinearIndices((n, n))
+  layout = get_layout(gp)
 
   # add plots to axes
   for i in 1:n, j in 1:n
-    ax = fig.content[I[j, i]]
+    ax = Makie.content(layout[i, j])
 
     # retrieve coordinates and counts
     hs = f.abscissas
@@ -185,5 +194,6 @@ function funplot!(
       Makie.annotation!(ax, hs, fs, text=string.(ns), fontsize=textsize)
     end
   end
-  fig
+  gp
 end
+

--- a/ext/GeoStatsFunctionsMakieExt/funplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/funplot.jl
@@ -13,27 +13,27 @@ function funplot(f; labels=nothing, kwargs...)
     Makie.Axis(fig[i, j], title=title)
   end
   # fill figure with plots
-  funplot!(fig, f; kwargs...)
+  funplot!(fig.layout, f; kwargs...)
   fig
 end
 
-function funplot(gp::GridPos, f; labels=nothing, kwargs...)
+function funplot(pos, f; labels=nothing, kwargs...)
   # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
   # initialize figure
-  layout = _layout(gp)
+  layout = _layout(pos)
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
     Makie.Axis(layout[i, j], title=title)
   end
   # fill figure with plots
   funplot!(layout, f; kwargs...)
-  gp
+  pos
 end
 
 function funplot!(
-  layout::Union{Makie.Figure, Makie.GridLayout},
+  layout::Makie.GridLayout,
   f::GeoStatsFunction;
   # common options
   color=:teal,
@@ -55,10 +55,8 @@ function funplot!(
   # add plots to axes
   d = length(F)
   n = nvariates(f)
-  gl = layout isa Makie.Figure ? layout.layout : layout
-  I = LinearIndices((n, n))
   for i in 1:n, j in 1:n
-    ax = gl.content[I[j, i]].content
+    ax = Makie.content(layout[i, j])
     for (k, Fₖ) in enumerate(F)
       Makie.lines!(ax, hs, Fₖ[i, j], color=color, linewidth=size, linestyle=style[k], label=label[k])
       if _istransiogram(f)
@@ -115,7 +113,7 @@ function _anisobasis(f::CarleTransiogram{N}) where {N}
 end
 
 function funplot!(
-  layout::Union{Makie.Figure, Makie.GridLayout},
+  layout::Makie.GridLayout,
   f::EmpiricalGeoStatsFunction;
   # common options
   color=:slategray,
@@ -128,17 +126,23 @@ function funplot!(
   showhist=true,
   histcolor=:slategray
 )
+  # number of variables
   n = nvariates(f)
-  gl = layout isa Makie.Figure ? layout.layout : layout
-  I = LinearIndices((n, n))
+  # add plots to axes
   for i in 1:n, j in 1:n
-    ax = gl.content[I[j, i]].content
+    ax = Makie.content(layout[i, j])
+    # retrieve coordinates and counts
     hs = f.abscissas
     fs = _istransiogram(f) ? f.ordinates[i, j] : f.ordinates
     ns = f.counts
     hmax = isnothing(maxlag) ? _maxlag(f) : GeoStatsFunctions.aslen(maxlag)
-    hs = hs[ns .> 0]; fs = fs[ns .> 0]; ns = ns[ns .> 0]
-    ns = ns[hs .≤ hmax]; fs = fs[hs .≤ hmax]; hs = hs[hs .≤ hmax]
+    hs = hs[ns .> 0]
+    fs = fs[ns .> 0]
+    ns = ns[ns .> 0]
+    # discard above maximum lag
+    ns = ns[hs .≤ hmax]
+    fs = fs[hs .≤ hmax]
+    hs = hs[hs .≤ hmax]
     if showhist
       ms = ns * (maximum(fs) / maximum(ns)) / 10
       Makie.barplot!(ax, hs, ms, color=histcolor, alpha=0.3, gap=0.0)

--- a/ext/GeoStatsFunctionsMakieExt/funplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/funplot.jl
@@ -2,70 +2,55 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-function funplot(gp::GridPos, f; labels=nothing, kwargs...)
-  # variable names
+function funplot(f; labels=nothing, kwargs...)
+  fig = Makie.Figure()
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
+  for i in 1:n, j in 1:n
+    title = n > 1 ? "$(l[i]) → $(l[j])" : ""
+    Makie.Axis(fig[i, j], title=title)
+  end
+  funplot!(fig, f; kwargs...)
+  fig
+end
 
-  layout = get_layout(gp)
-
-  # initialize axis grid
+function funplot(gp::GridPos, f; labels=nothing, kwargs...)
+  n = nvariates(f)
+  l = isnothing(labels) ? (1:n) : labels
+  layout = _layout(gp)
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
     Makie.Axis(layout[i, j], title=title)
   end
-
-  # fill figure with plots
-  funplot!(gp, f; kwargs...)
-
+  funplot!(layout, f; kwargs...)
   gp
 end
 
-function funplot(f; figure=(;), kwargs...)
-  fig = Makie.Figure(; figure...)
-  funplot(fig, f; kwargs...)
-  fig
-end
-
 function funplot!(
-  gp::GridPos,
+  layout::Union{Makie.Figure, Makie.GridLayout},
   f::GeoStatsFunction;
-  # common options
   color=:teal,
   size=1.5,
   maxlag=nothing
 )
-  # maximum lag
   hmax = isnothing(maxlag) ? _maxlag(f) : GeoStatsFunctions.aslen(maxlag)
-
-  # lag range starting at 1e-6 to avoid nugget artifact
   hs = range(1e-6 * oneunit(hmax), stop=hmax, length=100)
-
-  # evaluate function
   F = _eval(f, hs)
-
-  # mean lengths and proportions
   l = _istransiogram(f) ? meanlengths(f) : nothing
   p = _istransiogram(f) ? proportions(f) : nothing
-
-  # aesthetic options
   label = Dict(1 => "1ˢᵗ axis", 2 => "2ⁿᵈ axis", 3 => "3ʳᵈ axis")
   style = Dict(1 => :solid, 2 => :dash, 3 => :dot)
-
-  # add plots to axes
   d = length(F)
   n = nvariates(f)
-  layout = get_layout(gp)
+  gl = layout isa Makie.Figure ? layout.layout : layout
+  I = LinearIndices((n, n))
   for i in 1:n, j in 1:n
-    ax = Makie.content(layout[i, j])
+    ax = gl.content[I[j, i]].content
     for (k, Fₖ) in enumerate(F)
-      # display function
       Makie.lines!(ax, hs, Fₖ[i, j], color=color, linewidth=size, linestyle=style[k], label=label[k])
       if _istransiogram(f)
         if i == j
-          # display mean lengths
           Makie.lines!(ax, [zero(hmax), l[i]], [1.0, 0.0], color=:slategray, linewidth=size, linestyle=:dash)
-          # display proportions
           Makie.hlines!(ax, p[i], color=:slategray, linewidth=size, linestyle=:dash)
         end
       end
@@ -73,32 +58,21 @@ function funplot!(
     position = (i == j) && isbanded(f) ? :rt : :rb
     d > 1 && Makie.axislegend(ax, position=position)
   end
-  gp
+  layout
 end
 
 _eval(f, hs) = isisotropic(f) ? _isoeval(f, hs) : _anisoeval(f, hs)
 
 function _isoeval(f, hs)
-  # auxiliary parameters
   n = nvariates(f)
-
-  # evaluate all lags
   fs = f.(hs)
-
-  # reshape result
   Fᵢₛₒ = [getindex.(fs, i, j) for i in 1:n, j in 1:n]
-
   [Fᵢₛₒ]
 end
 
 function _anisoeval(f, hs)
-  # auxiliary parameters
   n = nvariates(f)
-
-  # reference point and basis vectors
   p, v = _anisobasis(f)
-
-  # evaluate along basis vectors
   map(v) do vⱼ
     fs = [f(p, p + ustrip(h) * vⱼ) for h in hs]
     [getindex.(fs, i, j) for i in 1:n, j in 1:n]
@@ -106,47 +80,33 @@ function _anisoeval(f, hs)
 end
 
 function _anisobasis(f)
-  # auxiliary parameters
   b = metricball(f)
   R = rotation(b)
   r = radii(b)
   d = length(r)
   U = eltype(r)
-
-  # reference point
   p = Point(ntuple(i -> U(0), d))
-
-  # rotated basis
   v = ntuple(d) do j
     R * Vec(ntuple(i -> U(i == j), d))
   end
-
   p, v
 end
 
 function _anisobasis(f::CarleTransiogram{N}) where {N}
-  # auxiliary parameters
   U = typeof(range(f))
-
-  # reference point
   p = Point(ntuple(i -> U(0), N))
-
-  # axis-aligned basis
   v = ntuple(N) do j
     Vec(ntuple(i -> U(i == j), N))
   end
-
   p, v
 end
 
 function funplot!(
-  gp::GridPos,
+  layout::Union{Makie.Figure, Makie.GridLayout},
   f::EmpiricalGeoStatsFunction;
-  # common options
   color=:slategray,
   size=1.5,
   maxlag=nothing,
-  # empirical options
   style=:solid,
   pointsize=12,
   showtext=true,
@@ -154,46 +114,25 @@ function funplot!(
   showhist=true,
   histcolor=:slategray
 )
-  # number of variables
   n = nvariates(f)
-  layout = get_layout(gp)
-
-  # add plots to axes
+  gl = layout isa Makie.Figure ? layout.layout : layout
+  I = LinearIndices((n, n))
   for i in 1:n, j in 1:n
-    ax = Makie.content(layout[i, j])
-
-    # retrieve coordinates and counts
+    ax = gl.content[I[j, i]].content
     hs = f.abscissas
     fs = _istransiogram(f) ? f.ordinates[i, j] : f.ordinates
     ns = f.counts
-
-    # retrieve maximum lag
     hmax = isnothing(maxlag) ? _maxlag(f) : GeoStatsFunctions.aslen(maxlag)
-
-    # discard empty bins
-    hs = hs[ns .> 0]
-    fs = fs[ns .> 0]
-    ns = ns[ns .> 0]
-
-    # discard above maximum lag
-    ns = ns[hs .≤ hmax]
-    fs = fs[hs .≤ hmax]
-    hs = hs[hs .≤ hmax]
-
-    # visualize histogram
+    hs = hs[ns .> 0]; fs = fs[ns .> 0]; ns = ns[ns .> 0]
+    ns = ns[hs .≤ hmax]; fs = fs[hs .≤ hmax]; hs = hs[hs .≤ hmax]
     if showhist
       ms = ns * (maximum(fs) / maximum(ns)) / 10
       Makie.barplot!(ax, hs, ms, color=histcolor, alpha=0.3, gap=0.0)
     end
-
-    # visualize function
     Makie.scatterlines!(ax, hs, fs, color=color, markersize=pointsize, linewidth=size, linestyle=style)
-
-    # visualize text counts
     if showtext
       Makie.annotation!(ax, hs, fs, text=string.(ns), fontsize=textsize)
     end
   end
-  gp
+  layout
 end
-

--- a/ext/GeoStatsFunctionsMakieExt/surfplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/surfplot.jl
@@ -6,20 +6,34 @@ function surfplot(f; labels=nothing, kwargs...)
   # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
-
   # initialize figure
   fig = Makie.Figure()
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
-    ax = Makie.PolarAxis(fig[i, j], title=title)
+    Makie.PolarAxis(fig[i, j], title=title)
   end
-
   # fill figure with plots
-  surfplot!(fig, f; kwargs...)
+  surfplot!(fig.layout, f; kwargs...)
+  fig
+end
+
+function surfplot(pos, f; labels=nothing, kwargs...)
+  # variable names
+  n = nvariates(f)
+  l = isnothing(labels) ? (1:n) : labels
+  # initialize figure
+  layout = _layout(pos)
+  for i in 1:n, j in 1:n
+    title = n > 1 ? "$(l[i]) → $(l[j])" : ""
+    Makie.PolarAxis(layout[i, j], title=title)
+  end
+  # fill figure with plots
+  surfplot!(layout, f; kwargs...)
+  pos
 end
 
 function surfplot!(
-  fig::Makie.Figure,
+  layout::Makie.GridLayout,
   f::GeoStatsFunction;
   # common options
   colormap=:viridis,
@@ -85,20 +99,19 @@ function surfplot!(
   rs = [zero(eltype(rs)); rs]
   Z = [Z[:, 1:1] Z]
 
-  I = LinearIndices((n, n))
   for i in 1:n, j in 1:n
-    ax = fig.content[I[j, i]]
+    ax = Makie.content(layout[i, j])
     Zᵢⱼ = getindex.(Z, i, j)
     Makie.surface!(ax, θs, ustrip.(rs), ustrip.(Zᵢⱼ), colormap=colormap, shading=false)
   end
-  fig
+  layout
 end
 
 _ncoords(f) = length(radii(metricball(f)))
 _ncoords(::CarleTransiogram{N}) where {N} = N
 
 function surfplot!(
-  fig::Makie.Figure,
+  layout::Makie.GridLayout,
   f::EmpiricalGeoStatsSurface;
   # common options
   colormap=:viridis,
@@ -132,9 +145,8 @@ function surfplot!(
   # hide hole at center
   rs = [zero(eltype(rs)); rs]
 
-  I = LinearIndices((n, n))
   for i in 1:n, j in 1:n
-    ax = fig.content[I[j, i]]
+    ax = Makie.content(layout[i, j])
 
     # values in matrix form
     Zᵢⱼ = _istransiogram(f) ? getindex.(zs, i, j) : zs
@@ -151,5 +163,5 @@ function surfplot!(
 
     Makie.surface!(ax, θs, ustrip.(rs), ustrip.(Z), colormap=colormap, shading=false)
   end
-  fig
+  layout
 end

--- a/ext/GeoStatsFunctionsMakieExt/surfplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/surfplot.jl
@@ -2,24 +2,33 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-function surfplot(f; labels=nothing, kwargs...)
+function surfplot(gp::GridPos, f; labels=nothing, kwargs...)
   # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
 
-  # initialize figure
-  fig = Makie.Figure()
+  layout = get_layout(gp)
+
+  # initialize polar axis grid
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
-    ax = Makie.PolarAxis(fig[i, j], title=title)
+    Makie.PolarAxis(layout[i, j], title=title)
   end
 
   # fill figure with plots
-  surfplot!(fig, f; kwargs...)
+  surfplot!(gp, f; kwargs...)
+
+  gp
+end
+
+function surfplot(f; figure=(;), kwargs...)
+  fig = Makie.Figure(; figure...)
+  surfplot(fig, f; kwargs...)
+  fig
 end
 
 function surfplot!(
-  fig::Makie.Figure,
+  gp::GridPos,
   f::GeoStatsFunction;
   # common options
   colormap=:viridis,
@@ -85,20 +94,20 @@ function surfplot!(
   rs = [zero(eltype(rs)); rs]
   Z = [Z[:, 1:1] Z]
 
-  I = LinearIndices((n, n))
+  layout = get_layout(gp)
   for i in 1:n, j in 1:n
-    ax = fig.content[I[j, i]]
+    ax = Makie.content(layout[i, j])
     Zᵢⱼ = getindex.(Z, i, j)
     Makie.surface!(ax, θs, ustrip.(rs), ustrip.(Zᵢⱼ), colormap=colormap, shading=false)
   end
-  fig
+  gp
 end
 
 _ncoords(f) = length(radii(metricball(f)))
 _ncoords(::CarleTransiogram{N}) where {N} = N
 
 function surfplot!(
-  fig::Makie.Figure,
+  gp::GridPos,
   f::EmpiricalGeoStatsSurface;
   # common options
   colormap=:viridis,
@@ -132,9 +141,9 @@ function surfplot!(
   # hide hole at center
   rs = [zero(eltype(rs)); rs]
 
-  I = LinearIndices((n, n))
+  layout = get_layout(gp)
   for i in 1:n, j in 1:n
-    ax = fig.content[I[j, i]]
+    ax = Makie.content(layout[i, j])
 
     # values in matrix form
     Zᵢⱼ = _istransiogram(f) ? getindex.(zs, i, j) : zs
@@ -151,5 +160,5 @@ function surfplot!(
 
     Makie.surface!(ax, θs, ustrip.(rs), ustrip.(Z), colormap=colormap, shading=false)
   end
-  fig
+  gp
 end

--- a/ext/GeoStatsFunctionsMakieExt/surfplot.jl
+++ b/ext/GeoStatsFunctionsMakieExt/surfplot.jl
@@ -2,33 +2,24 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-function surfplot(gp::GridPos, f; labels=nothing, kwargs...)
+function surfplot(f; labels=nothing, kwargs...)
   # variable names
   n = nvariates(f)
   l = isnothing(labels) ? (1:n) : labels
 
-  layout = get_layout(gp)
-
-  # initialize polar axis grid
+  # initialize figure
+  fig = Makie.Figure()
   for i in 1:n, j in 1:n
     title = n > 1 ? "$(l[i]) → $(l[j])" : ""
-    Makie.PolarAxis(layout[i, j], title=title)
+    ax = Makie.PolarAxis(fig[i, j], title=title)
   end
 
   # fill figure with plots
-  surfplot!(gp, f; kwargs...)
-
-  gp
-end
-
-function surfplot(f; figure=(;), kwargs...)
-  fig = Makie.Figure(; figure...)
-  surfplot(fig, f; kwargs...)
-  fig
+  surfplot!(fig, f; kwargs...)
 end
 
 function surfplot!(
-  gp::GridPos,
+  fig::Makie.Figure,
   f::GeoStatsFunction;
   # common options
   colormap=:viridis,
@@ -94,20 +85,20 @@ function surfplot!(
   rs = [zero(eltype(rs)); rs]
   Z = [Z[:, 1:1] Z]
 
-  layout = get_layout(gp)
+  I = LinearIndices((n, n))
   for i in 1:n, j in 1:n
-    ax = Makie.content(layout[i, j])
+    ax = fig.content[I[j, i]]
     Zᵢⱼ = getindex.(Z, i, j)
     Makie.surface!(ax, θs, ustrip.(rs), ustrip.(Zᵢⱼ), colormap=colormap, shading=false)
   end
-  gp
+  fig
 end
 
 _ncoords(f) = length(radii(metricball(f)))
 _ncoords(::CarleTransiogram{N}) where {N} = N
 
 function surfplot!(
-  gp::GridPos,
+  fig::Makie.Figure,
   f::EmpiricalGeoStatsSurface;
   # common options
   colormap=:viridis,
@@ -141,9 +132,9 @@ function surfplot!(
   # hide hole at center
   rs = [zero(eltype(rs)); rs]
 
-  layout = get_layout(gp)
+  I = LinearIndices((n, n))
   for i in 1:n, j in 1:n
-    ax = Makie.content(layout[i, j])
+    ax = fig.content[I[j, i]]
 
     # values in matrix form
     Zᵢⱼ = _istransiogram(f) ? getindex.(zs, i, j) : zs
@@ -160,5 +151,5 @@ function surfplot!(
 
     Makie.surface!(ax, θs, ustrip.(rs), ustrip.(Z), colormap=colormap, shading=false)
   end
-  gp
+  fig
 end

--- a/ext/GeoStatsFunctionsMakieExt/utils.jl
+++ b/ext/GeoStatsFunctionsMakieExt/utils.jl
@@ -14,3 +14,18 @@ _istransiogram(f) = false
 _istransiogram(t::Transiogram) = true
 _istransiogram(t::EmpiricalTransiogram) = true
 _istransiogram(t::EmpiricalTransiogramSurface) = true
+
+const GridPos = Union{Makie.Figure, Makie.GridLayout, Makie.GridPosition, Makie.GridSubposition}
+
+function get_layout(gp::Makie.Figure)
+  gp.layout
+end
+
+function get_layout(gp::Makie.GridLayout)
+  gp
+end
+
+function get_layout(gp::Union{Makie.GridPosition, Makie.GridSubposition})
+  Makie.GridLayout(gp)
+end
+

--- a/ext/GeoStatsFunctionsMakieExt/utils.jl
+++ b/ext/GeoStatsFunctionsMakieExt/utils.jl
@@ -15,8 +15,6 @@ _istransiogram(t::Transiogram) = true
 _istransiogram(t::EmpiricalTransiogram) = true
 _istransiogram(t::EmpiricalTransiogramSurface) = true
 
-const GridPos = Union{Makie.Figure, Makie.GridLayout, Makie.GridPosition, Makie.GridSubposition}
-
 _layout(fig::Makie.Figure) = fig.layout
 _layout(gl::Makie.GridLayout) = gl
 _layout(gp::Makie.GridPosition) = Makie.GridLayout(gp)

--- a/ext/GeoStatsFunctionsMakieExt/utils.jl
+++ b/ext/GeoStatsFunctionsMakieExt/utils.jl
@@ -17,15 +17,7 @@ _istransiogram(t::EmpiricalTransiogramSurface) = true
 
 const GridPos = Union{Makie.Figure, Makie.GridLayout, Makie.GridPosition, Makie.GridSubposition}
 
-function get_layout(gp::Makie.Figure)
-  gp.layout
-end
-
-function get_layout(gp::Makie.GridLayout)
-  gp
-end
-
-function get_layout(gp::Union{Makie.GridPosition, Makie.GridSubposition})
-  Makie.GridLayout(gp)
-end
-
+_layout(fig::Makie.Figure) = fig.layout
+_layout(gl::Makie.GridLayout) = gl
+_layout(gp::Makie.GridPosition) = Makie.GridLayout(gp)
+_layout(gp::Makie.GridSubposition) = Makie.GridLayout(gp)


### PR DESCRIPTION
## Summary

This PR refactors `funplot` and `surfplot` to better integrate with Makie layouts.

### Changes

* Added support for layout-aware plotting.
* Improved composition with Makie figures and grid layouts.
* Refactored plotting implementation to follow Makie layout patterns.
* Preserved existing functionality where possible.

### Motivation

Issue #576 highlighted that `funplot` and `surfplot` were not easily composable within Makie layouts. This change improves interoperability with Makie figures and layout components.

Fixes JuliaEarth/GeoStats.jl#576
